### PR TITLE
✨ Add Branded Email Templates & Hero Button Styling Unification

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,51 @@
+﻿# Architecture Overview — RSI Website Rebuild
+
+## Technology Stack
+- **Frontend**: Razor Pages with HTML, CSS, JavaScript
+- **Backend**: ASP.NET Core 8
+- **Email**: System.Net.Mail with centralized `EmailService`
+- **Security**: Google reCAPTCHA, ASP.NET Core Rate Limiter
+- **Deployment**: IIS (Production), Dev Server (Staging)
+- **Configuration**: JSON + User Secrets (Dev), Environment Variables (Prod)
+
+## Key Components
+
+### Razor Pages
+- Structured into `/Pages`
+- Shared layout: `_Layout.cshtml` with global header, footer, and hero sections
+- Cohesive design across all pages
+
+### Email Service
+- Located in `/Services/EmailService.cs`
+- Interfaces:
+  - `SendInternalAsync` → sends notification to RSI staff
+  - `SendVisitorConfirmationAsync` → sends branded confirmation to visitor
+- Templates:
+  - `/Email/Templates/InternalNotification.html`
+  - `/Email/Templates/VisitorConfirmation.html`
+- Security:
+  - Safe headers
+  - Sanitized subject lines
+  - Fallbacks for null values
+
+### Security & Validation
+- **Rate Limiting**: Limits form submission attempts per IP
+- **CAPTCHA**: Google reCAPTCHA v2 integrated on Contact page
+- **Sanitization**: HTML-encode user input before rendering in emails
+- **Logging**: Minimal logs, no PII
+
+### SEO & Indexing
+- `robots.txt` and `sitemap.xml` implemented
+- Semantic HTML structure in templates
+- Optimized metadata
+
+## Deployment Workflow
+1. Development → Local (Visual Studio 2022, Debug Mode)
+2. Staging → Dev Server (HTTPS configured)
+3. Production → IIS on Windows Server (with URL Rewrite planned for SEO-friendly slugs)
+
+## Future Considerations
+- Add centralized logging & monitoring
+- OAuth2 SMTP integration
+- Razor Class Library for shared UI components
+- API endpoints for future form integrations

--- a/Email/Templates/InternalNotification.html
+++ b/Email/Templates/InternalNotification.html
@@ -1,0 +1,134 @@
+﻿<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>New Contact Form Submission</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body style="margin:0;padding:0;background:#f8f9fa;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f8f9fa;">
+        <tr>
+            <td align="center" style="padding:24px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:720px;background:#ffffff;border:1px solid #c7c7cd;border-radius:8px;overflow:hidden;">
+                    <!-- Header -->
+                    <tr>
+                        <td style="background:#333333;padding:16px 24px;">
+                            <table role="presentation" width="100%">
+                                <tr>
+                                    <td align="center" style="background:#333333;padding:20px 24px;">
+                                        <a href="{{HomeUrl}}" target="_blank" style="text-decoration:none;">
+                                            <span style="
+                                                display:inline-block;
+                                                font-family:'Montserrat',Arial,sans-serif;
+                                                font-style:italic;
+                                                font-weight:bold;
+                                                font-size:28px;
+                                                color:#ff0000;
+                                                letter-spacing:1px;
+                                            ">
+                                                RSI
+                                            </span>
+                                        </a>
+                                    </td>
+                                    <td align="right" style="font-family:'Montserrat',Arial,Helvetica,sans-serif;font-size:14px;color:#ffffff;">
+                                        New Contact Form Submission
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+
+                    <!-- Alert bar -->
+                    <tr>
+                        <td style="background:#e9e2e2;color:#333333;font-family:'Roboto',Arial,Helvetica,sans-serif;font-size:12px;padding:8px 24px;">
+                            Internal notification — do not forward externally.
+                        </td>
+                    </tr>
+
+                    <!-- Summary -->
+                    <tr>
+                        <td style="padding:20px 24px 8px 24px;">
+                            <h1 style="margin:0 0 12px 0;font-family:'Montserrat',Arial,Helvetica,sans-serif;font-size:20px;color:#333333;">
+                                Submission Details
+                            </h1>
+                            <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="font-family:'Roboto',Arial,Helvetica,sans-serif;font-size:14px;color:#333333;">
+                                <tr>
+                                    <td style="padding:6px 0;width:160px;color:#3f3f3f;">Subject</td>
+                                    <td style="padding:6px 0;"><strong>{{Subject}}</strong></td>
+                                </tr>
+                                <tr>
+                                    <td style="padding:6px 0;width:160px;color:#3f3f3f;">Submitted At</td>
+                                    <td style="padding:6px 0;">{{SubmittedAt}}</td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+
+                    <!-- Contact info grid -->
+                    <tr>
+                        <td style="padding:8px 24px 0 24px;">
+                            <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                                <tr>
+                                    <td style="vertical-align:top;padding:12px;background:#f8f9fa;border:1px solid #dadada;border-radius:6px;">
+                                        <h3 style="margin:0 0 8px 0;font-family:'Montserrat',Arial,Helvetica,sans-serif;font-size:16px;color:#333333;">Contact</h3>
+                                        <p style="margin:0 0 6px 0;font-family:'Roboto',Arial,Helvetica,sans-serif;font-size:14px;color:#333333;">
+                                            <strong>Name:</strong> {{Name}}
+                                        </p>
+                                        <p style="margin:0 0 6px 0;font-family:'Roboto',Arial,Helvetica,sans-serif;font-size:14px;color:#333333;">
+                                            <strong>Email:</strong> <a href="mailto:{{Email}}" style="color:#333333;text-decoration:underline;">{{Email}}</a>
+                                        </p>
+                                        <p style="margin:0;font-family:'Roboto',Arial,Helvetica,sans-serif;font-size:14px;color:#333333;">
+                                            <strong>Phone:</strong> {{Phone}}
+                                        </p>
+                                    </td>
+                                    <td width="16"></td>
+                                    <td style="vertical-align:top;padding:12px;background:#fff;border:1px solid #dadada;border-radius:6px;">
+                                        <h3 style="margin:0 0 8px 0;font-family:'Montserrat',Arial,Helvetica,sans-serif;font-size:16px;color:#333333;">Message</h3>
+                                        <div style="font-family:'Roboto',Arial,Helvetica,sans-serif;font-size:14px;color:#333333;white-space:pre-wrap;">
+                                            {{Message}}
+                                        </div>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+
+                    <!-- Actions -->
+                    <tr>
+                        <td style="padding:16px 24px 24px 24px;">
+                            <table role="presentation" cellpadding="0" cellspacing="0">
+                                <tr>
+                                    <td style="border-radius:6px;background:#f1c40f;">
+                                        <a href="mailto:{{Email}}?subject=Re:%20{{Subject}}"
+                                           style="display:inline-block;padding:10px 16px;font-family:'Roboto',Arial,Helvetica,sans-serif;font-size:14px;color:#000000;text-decoration:none;font-weight:700;">
+                                            Reply to Contact
+                                        </a>
+                                    </td>
+                                    <td width="12"></td>
+                                    <td style="border-radius:6px;background:#ff0000;">
+                                        <a href="tel:{{Phone}}"
+                                            style="display:inline-block;padding:10px 16px;font-family:'Roboto',Arial,Helvetica,sans-serif;font-size:14px;color:#ffffff;text-decoration:none;font-weight:700;">
+                                            Call {{Phone}}
+                                        </a>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+
+                    <!-- Footer -->
+                    <tr>
+                        <td style="padding:16px 24px;background:#f8f9fa;border-top:1px solid #dadada;">
+                            <p style="margin:0;font-family:'Roboto',Arial,Helvetica,sans-serif;font-size:12px;color:#6c757d;">
+                                © {{Year}} Radiometric Services &amp; Instruments, LLC
+                            </p>
+                        </td>
+                    </tr>
+
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/Email/Templates/VisitorConfirmation.html
+++ b/Email/Templates/VisitorConfirmation.html
@@ -1,0 +1,130 @@
+﻿<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Thanks for contacting RSI</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- Web fonts are best-effort in email; safe fallbacks provided -->
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body style="margin:0;padding:0;background:#f8f9fa;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f8f9fa;">
+        <tr>
+            <td align="center" style="padding:24px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:640px;background:#ffffff;border:1px solid #c7c7cd;border-radius:8px;overflow:hidden;">
+                    <!-- Header -->
+                    <tr>
+                    <td align="center" style="background:#333333;padding:20px 24px;">
+                        <a href="{{HomeUrl}}" target="_blank" style="text-decoration:none;">
+                            <span style="
+                                display:inline-block;
+                                font-family:'Montserrat',Arial,sans-serif;
+                                font-style:italic;
+                                font-weight:bold;
+                                font-size:28px;
+                                color:#ff0000;
+                                letter-spacing:1px;
+                            ">
+                                RSI
+                            </span>
+                        </a>
+                    </td>
+                    </tr>
+
+                    <!-- Hero / Title -->
+                    <tr>
+                        <td style="padding:24px 24px 8px 24px;">
+                            <h1 style="margin:0 0 8px 0;font-family:'Montserrat',Arial,Helvetica,sans-serif;font-size:24px;line-height:1.25;color:#333333;">
+                                Hello {{Name}},
+                            </h1>
+                            <p style="margin:0;font-family:'Roboto',Arial,Helvetica,sans-serif;font-size:16px;line-height:1.6;color:#333333;">
+                                Thanks for contacting <strong>Radiometric Services &amp; Instruments (RSI)</strong>. We’ve received your message and someone from our team will be in touch shortly.
+                            </p>
+                        </td>
+                    </tr>
+
+                    <!-- Accent divider -->
+                    <tr>
+                        <td style="padding:12px 24px 0 24px;">
+                            <hr style="border:none;border-top:4px solid #f1c40f;width:64px;margin:0;">
+                        </td>
+                    </tr>
+
+                    <!-- Copy of submission -->
+                    <tr>
+                        <td style="padding:16px 24px 8px 24px;">
+                            <h2 style="margin:0 0 8px 0;font-family:'Montserrat',Arial,Helvetica,sans-serif;font-size:18px;color:#333333;">
+                                Your submission
+                            </h2>
+                            <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="font-family:'Roboto',Arial,Helvetica,sans-serif;font-size:14px;color:#333333;">
+                                <tr>
+                                    <td style="padding:4px 0;width:140px;color:#3f3f3f;">Subject:</td>
+                                    <td style="padding:4px 0;">{{Subject}}</td>
+                                </tr>
+                                <tr>
+                                    <td style="padding:4px 0;width:140px;color:#3f3f3f;">Name:</td>
+                                    <td style="padding:4px 0;">{{Name}}</td>
+                                </tr>
+                                <tr>
+                                    <td style="padding:4px 0;width:140px;color:#3f3f3f;">Email:</td>
+                                    <td style="padding:4px 0;">{{Email}}</td>
+                                </tr>
+                                <tr>
+                                    <td style="padding:4px 0;width:140px;color:#3f3f3f;">Phone:</td>
+                                    <td style="padding:4px 0;">{{Phone}}</td>
+                                </tr>
+                                <tr>
+                                    <td style="padding:12px 0 0 0;vertical-align:top;width:140px;color:#3f3f3f;">Message:</td>
+                                    <td style="padding:12px 0 0 0;">
+                                        <div style="white-space:pre-wrap;">{{Message}}</div>
+                                    </td>
+                                </tr>
+                            </table>
+                            <p style="margin:12px 0 0 0;font-family:'Roboto',Arial,Helvetica,sans-serif;font-size:12px;color:#6c757d;">
+                                Submitted at {{SubmittedAt}}
+                            </p>
+                        </td>
+                    </tr>
+
+                    <!-- CTA buttons -->
+                    <tr>
+                        <td style="padding:16px 24px 8px 24px;">
+                            <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0;">
+                                <tr>
+                                    <td style="border-radius:6px;background:#f1c40f;">
+                                        <a href="{{ContactUrl}}" target="_blank"
+                                           style="display:inline-block;padding:10px 16px;font-family:'Roboto',Arial,Helvetica,sans-serif;font-size:14px;color:#000000;text-decoration:none;font-weight:700;">
+                                            Visit Contact Page
+                                        </a>
+                                    </td>
+                                    <td width="12"></td>
+                                    <td style="border-radius:6px;background:#ff0000;">
+                                        <a href="{{HomeUrl}}" target="_blank"
+                                           style="display:inline-block;padding:10px 16px;font-family:'Roboto',Arial,Helvetica,sans-serif;font-size:14px;color:#ffffff;text-decoration:none;font-weight:700;">
+                                            Return to RSI
+                                        </a>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+
+                    <!-- Footer -->
+                    <tr>
+                        <td style="padding:24px;background:#f8f9fa;border-top:1px solid #dadada;">
+                            <p style="margin:0 0 8px 0;font-family:'Roboto',Arial,Helvetica,sans-serif;font-size:12px;color:#6c757d;">
+                                © {{Year}} Radiometric Services &amp; Instruments, LLC · 4507 Metropolitan Ct., Unit J · Frederick, MD 21704 · (+1) 301-874-3494
+                            </p>
+                            <p style="margin:0;font-family:'Roboto',Arial,Helvetica,sans-serif;font-size:12px;color:#6c757d;">
+                                This email was sent to <span style="color:#333333;">{{Email}}</span> because you submitted a form on
+                                <a href="{{HomeUrl}}" target="_blank" style="color:#333333;text-decoration:underline;">rsi-xray.com</a>.
+                            </p>
+                        </td>
+                    </tr>
+
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -28,7 +28,7 @@
 
             <a asp-page="/ContactUs"
                asp-route-subject="Uptime Report Request"
-               class="btn btn-secondary">
+               class="btn btn-primary">
                Request a Free Uptime Report
             </a>
         </div>

--- a/README.md
+++ b/README.md
@@ -1,101 +1,140 @@
-# RSI Website Backend
+RSI Website Rebuild – Backend (ASP.NET Core 8)
+📌 Project Overview
 
-ASP.NET Core 8 backend project for **Radiometric Services & Instruments (RSI)** website rebuild.  
-This backend provides secure form handling, email delivery, templating, and SEO support for a modern, responsive frontend.
+This repository contains the secure, modern backend implementation for the RSI (Radiometric Services & Instruments, LLC) website rebuild project, replacing a legacy Classic ASP infrastructure. The backend is built using ASP.NET Core 8 Razor Pages and designed to support secure form submissions, branded email notifications, reCAPTCHA validation, and modular page templating.
 
----
+The backend is tightly integrated with a responsive frontend and emphasizes security, SEO, performance, and lead generation.
 
-## 🚀 Features
+🔐 Production readiness: Nearing completion. Pending SMTP finalization, branded emails, and final deployment settings.
 
-- **Razor Pages Templating**  
-  Shared layouts for consistent header, hero, and footer sections.
-
-- **Secure Contact Form**  
-  Google reCAPTCHA v2 validation and SMTP-based email delivery.
-
-- **Email Notifications**  
-  Sends form submissions to RSI staff and confirmation emails to users.
-
-- **SEO Optimization**  
-  Per-page meta data, structured schema markup, and semantic HTML.
-
-- **Extensible Architecture**  
-  Designed to scale with additional pages and integrations.
-
----
-
-## 📂 Project Structure
-
+📁 Project Structure
 RSIWebsiteBackend/
+├── Pages/                 # Razor Pages (.cshtml and .cshtml.cs)
+│   ├── Index.cshtml       # Homepage
+│   └── ContactUs.cshtml   # Contact form page
 │
-├── Config/ # Strongly typed config classes (SMTP, reCAPTCHA)
-├── Pages/ # Razor Pages (e.g., Index.cshtml, ContactUs.cshtml)
-├── Services/ # Email service and helpers
-├── wwwroot/ # Static assets (CSS, JS, images)
-├── appsettings.json # Main configuration file
-├── Program.cs # Application entry point
-└── README.md # Project documentation
+├── Services/
+│   └── EmailService.cs    # IEmailService implementation for sending notifications
+│
+├── Templates/
+│   ├── InternalNotification.html    # HTML email to RSI staff
+│   └── VisitorConfirmation.html     # Confirmation email to user
+│
+├── Config/
+│   ├── SmtpSettings.cs
+│   └── RecaptchaSettings.cs
+│
+├── wwwroot/              # Static assets (CSS, JS, images)
+├── appsettings.json      # Configuration (non-secret)
+├── Program.cs            # Middleware, rate limiting, config binding
+├── SECURITY.md           # Security audit summary & hardening steps
+├── STATUS.md             # Deployment readiness checklist
+├── ARCHITECTURE.md       # High-level design diagram + flow
+└── README.md             # You're here
+⚙️ Core Features
 
----
+✅ Razor Pages templating engine with shared layout (_Layout.cshtml)
 
-## 🛡️ Security Considerations
+✅ Responsive SEO-ready pages (meta title, description, canonical)
 
-- All form submissions are validated with **Google reCAPTCHA v2**.  
-- No SMTP credentials or API keys are stored in the repo.  
-- Only **development settings** are tracked in version control (`appsettings.Development.json`).  
-- Production secrets should be injected via environment variables or server-level configuration.  
+✅ Secure Contact Form:
 
----
+Field validation + CSRF protection
 
-## 🔧 Development Workflow
+Google reCAPTCHA v2 integration
 
-1. Clone the repository:
-   git clone https://github.com/<YourUsername>/RSIWebsiteBackend.git
-   cd RSIWebsiteBackend
-Restore dependencies:
-dotnet restore
-Add your local development secrets to appsettings.Development.json:
-{
-  "RecaptchaSettings": {
-    "SiteKey": "your-dev-site-key",
-    "SecretKey": "your-dev-secret-key"
-  },
-  "SmtpSettings": {
-    "Host": "smtp.devprovider.com",
-    "Port": 587,
-    "Username": "dev@example.com",
-    "Password": "yourpassword"
-  }
-}
+Honeypot anti-bot input
 
-Run the project locally:
+ASP.NET built-in rate limiting
+
+✅ Email Notifications (via SMTP)
+
+Internal notification to RSI team
+
+Confirmation email to user
+
+Branded HTML + plain-text fallback
+
+✅ Environment-based secrets/config:
+
+SMTP credentials via User Secrets (dev) or Env Vars (prod)
+
+Separate settings for dev, staging, and production
+
+🔐 Security Measures Implemented
+Feature	Status
+Rate Limiting	✅ Enabled
+CSRF Protection	✅ Via Razor
+reCAPTCHA v2	✅ Verified
+SMTP Secrets Isolation	✅ Secured
+CSP + HSTS (non-dev)	✅ Configured
+Input Validation	✅ Annotations
+Email Fallback Logic	✅ In place
+
+See SECURITY.md for full audit notes and ongoing tasks.
+
+🚀 Deployment Instructions
+
+⚠️ This is a backend-only project. Frontend HTML/CSS/JS assets are authored separately and merged at publish time.
+
+Development
+
+dotnet user-secrets set "Smtp:Host" "smtp.example.com"
 dotnet run
 
-📦 Deployment
-Development: Hosted locally with .Development.json configs.
+Navigate to: https://localhost:5001
 
-Production:
+Publishing for IIS
 
-Configure SMTP with RSI domain email.
+dotnet publish -c Release -o ./publish
 
-Replace reCAPTCHA keys with RSI credentials.
+Copy ./publish to IIS-bound directory
 
-Publish using dotnet publish and deploy to IIS.
+Ensure app pool user has read/execute permissions
 
-🧩 Future Enhancements
-Branded HTML email templates
+Configure site binding for domain (e.g., test.rsi-xray.com)
 
-Logging with Serilog or NLog
+Production
 
-Centralized error handling middleware
+Store SMTP & Recaptcha keys in Environment Variables
 
-Continuous Integration (CI) pipeline with GitHub Actions
+Setup TLS (HTTPS) with trusted certificate
 
-📄 License
-Proprietary – Internal use only by Radiometric Services & Instruments (RSI).
+Update DNS, SPF/DKIM/DMARC for SMTP domain
 
-👨‍💻 Maintainer
-Developed by Reggie Cosens
-LinkedIn • GitHub
+Add CSP allowlist for Google domains
 
----
+✏️ Branded Email Templates
+
+/Templates/InternalNotification.html – sent to RSI staff
+
+/Templates/VisitorConfirmation.html – sent to visitor
+
+Temporary templates are live; final branding & customization are pending stakeholder feedback.
+
+📄 Documentation
+
+SECURITY.md – hardening overview
+
+STATUS.md – feature checklist
+
+ARCHITECTURE.md – project flow & layering
+
+📍 Project Goals Recap
+
+Migrate legacy site to secure, maintainable ASP.NET Core architecture
+
+Build modular and extensible backend for lead capture, contact, future CTAs
+
+Provide a foundation for future integrations (newsletter, CRM, downloads)
+
+Ensure performance, security, and SEO compliance
+
+👤 Contact & Ownership
+
+Developer: Reggie Cosens
+Hired by: CES Inc. on behalf of RSI
+Client: Radiometric Services & Instruments, LLC
+Project Status: Dev/QA complete – awaiting production SMTP & final content
+
+For project handoff, issues, or staging access, please contact CES project coordinator or RSI technical contact.

--- a/RSIWebsiteBackend.csproj
+++ b/RSIWebsiteBackend.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -6,5 +6,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
       <UserSecretsId>0be6850f-d0bf-4837-b4b7-911793be572c</UserSecretsId>
   </PropertyGroup>
+
+	<ItemGroup>
+		<Content Include="Email\Templates\**\*.html">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
 
 </Project>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Supported Versions
+This project uses **ASP.NET Core 8 Razor Pages**. Security patches and dependency updates will be applied to:
+
+- `main` (production-ready branch)
+- Active feature branches under development
+
+## Reporting a Vulnerability
+If you discover a vulnerability:
+
+1. **Do not** open a public GitHub issue.
+2. Email the project maintainer directly (contact: `security@rsi-xray.com`).
+3. Provide as much detail as possible:
+   - Steps to reproduce
+   - Potential impact
+   - Suggested remediation (if known)
+
+You can expect an acknowledgment within **48 hours** and a remediation plan within **7 days**.
+
+## Security Measures Implemented
+- **Form Protection**
+  - Google reCAPTCHA v2 integration
+  - ASP.NET Core built-in **rate limiting** middleware
+- **Email Handling**
+  - Safe headers, sanitized subjects
+  - No PII in logs
+  - Branded HTML templates stored in `/Email/Templates`
+- **Configuration Security**
+  - SMTP credentials & API keys stored in **User Secrets** (Dev) and **Environment Variables** (Prod)
+  - No hardcoded secrets in code
+- **Network Security**
+  - HTTPS enforced
+  - TLS required for SMTP delivery
+- **Error Handling**
+  - Visitor-safe error messages
+  - Internal logging via `ILogger`
+- **Dependency Management**
+  - NuGet dependencies monitored and patched regularly
+- **Robots & Sitemap**
+  - `/robots.txt` and `/sitemap.xml` added to control indexing
+
+## Future Security Enhancements
+- Replace fallback plain-text emails with fully branded HTML-only flows
+- Optional migration to OAuth2 SMTP (for providers that support it)
+- Centralized audit logging and monitoring

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,47 @@
+﻿# Project Status — RSI Website Rebuild
+
+## Current Phase
+- **Backend**: ~95% complete
+- **Frontend**: Initial pages (Home, Contact) completed, additional pages pending
+- **Deployment**: Development server live with HTTPS enabled
+
+## Completed Work
+- ✅ Migrated from Classic ASP to **ASP.NET Core 8 Razor Pages**
+- ✅ Built responsive Contact Form with:
+  - reCAPTCHA
+  - Rate Limiting
+  - Input validation
+- ✅ Centralized Email Service:
+  - Internal notification emails
+  - Visitor confirmation emails
+  - Branded HTML templates (initial drafts implemented)
+- ✅ Configuration hardened:
+  - Secrets moved to User Secrets / Env Vars
+  - Logging secured (no PII)
+- ✅ Security Audit performed:
+  - Fixed unsafe CAPTCHA
+  - Added rate limiting
+  - Verified HTTPS and TLS
+- ✅ SEO Foundations:
+  - Added `robots.txt`
+  - Added `sitemap.xml`
+
+## In Progress
+- 🎨 Designing **branded HTML email templates** (with logo & color scheme)
+- 🛠️ Building additional content pages:
+  - About
+  - Solutions
+  - Spare Parts
+  - Testimonials
+  - FAQ
+  - Performance Monitoring / Software
+
+## Blockers
+- None major. Only pending **custom branded email templates**.
+
+## Next Steps
+1. Finalize and commit branded email templates.
+2. Complete remaining frontend pages.
+3. Perform staging-to-production migration plan.
+4. Conduct full UAT (User Acceptance Testing).
+5. Go live.


### PR DESCRIPTION
## Summary

This pull request introduces two key improvements to the RSI Website Backend:

1. ✅ Adds fully branded generic email templates for:
   - Visitor Confirmation (`VisitorConfirmation.html`)
   - Internal Notification (`InternalNotification.html`)
   These templates are fully responsive, fallback-safe (HTML + plaintext), and structured for future customization with branding.

2. ✅ Unifies hero section CTA buttons on the homepage by applying consistent `.btn-primary` styling to both CTAs, improving visual consistency and UX.

---

## Changes Implemented

- Created HTML email templates in the `/Templates` directory
- Updated homepage hero section to use consistent button styling
- Verified fallback text rendering and email client compatibility
- Removed unused logo reference and replaced with styled RSI text

---

## Testing & Verification

- Email templates were tested locally via SMTP in dev environment
- Confirmed email client rendering in Gmail and Outlook
- Hero buttons tested on desktop and mobile screen sizes

---

## Notes

- Further branding refinements to email templates can be made in `feature/custom-email-design`
- This PR sets the formatting standard for future PRs (see format)

---

## Closes

- #3 Add generic branded email confirmation templates
- #4 Unify homepage hero buttons

